### PR TITLE
Fix Broken Submission on Game Form

### DIFF
--- a/src/components/game/GameForm.js
+++ b/src/components/game/GameForm.js
@@ -10,8 +10,8 @@ export const GameForm = (props) => {
         provide some default values.
     */
   const [currentGame, setCurrentGame] = useState({
-    skill_level: 1,
-    number_of_players: 0,
+    skillLevel: 1,
+    numberOfPlayers: 0,
     title: "",
     maker: "",
     gameTypeId: 0,
@@ -89,32 +89,32 @@ export const GameForm = (props) => {
       </fieldset>
       <fieldset>
         <div className="form-group">
-          <label htmlFor="number_of_players">
-            Number of Players: {currentGame.number_of_players}{" "}
+          <label htmlFor="numberOfPlayers">
+            Number of Players: {currentGame.numberOfPlayers}{" "}
           </label>
           <input
             type="range"
-            name="number_of_players"
+            name="numberOfPlayers"
             min={0}
             max={20}
             className="form-control"
-            value={currentGame.number_of_players}
+            value={currentGame.numberOfPlayers}
             onChange={handleControlledInputChange}
           />
         </div>
       </fieldset>
       <fieldset>
         <div className="form-group">
-          <label htmlFor="skill_level">
-            Skill Level: {currentGame.skill_level}{" "}
+          <label htmlFor="skillLevel">
+            Skill Level: {currentGame.skillLevel}{" "}
           </label>
           <input
             type="range"
-            name="skill_level"
+            name="skillLevel"
             min={0}
             max={5}
             className="form-control"
-            value={currentGame.skill_level}
+            value={currentGame.skillLevel}
             onChange={handleControlledInputChange}
           />
         </div>

--- a/src/components/game/GameForm.js
+++ b/src/components/game/GameForm.js
@@ -32,6 +32,7 @@ export const GameForm = (props) => {
   const handleControlledInputChange = (event) => {
     const newGameState = Object.assign({}, currentGame);
     newGameState[event.target.name] = event.target.value;
+    console.log(newGameState);
     setCurrentGame(newGameState);
   };
 
@@ -54,12 +55,12 @@ export const GameForm = (props) => {
       </fieldset>
       <fieldset>
         <div className="form-group">
-          <label htmlFor="gametype">Game Type: </label>
+          <label htmlFor="gameTypeId">Game Type: </label>
           <select
-            name="gametype"
+            name="gameTypeId"
             required
             className="form-control"
-            value={currentGame.gametype}
+            value={currentGame.gameTypeId}
             onChange={handleControlledInputChange}
           >
             {gameTypes.map((gameType) => {


### PR DESCRIPTION
Previously, when the game form was submitted, it would throw errors due to missing keys and missing data. This change fixes that issue, by updating the keys on the client side to match the server.